### PR TITLE
CDMyPrometheusExporter: Labeled KPIs extension

### DIFF
--- a/src/188 - PrometheusExporter/Scripts/CreatePrometheusExporter.cdescript
+++ b/src/188 - PrometheusExporter/Scripts/CreatePrometheusExporter.cdescript
@@ -47,6 +47,7 @@
               "DeviceType": "ApplicationHost",
               "PropertiesIncluded": [
                 "QSenders;cde_qs_count",
+                "[QSenders].[LabeledKpis];cde_qs_count_per_scope",
                 "QSenderInRegistry;cde_qs_inregistry",
                 "QSReceivedTSM;cde_qs_tsm_received",
                 "QSSendErrors;cde_qs_tsm_send_errors",


### PR DESCRIPTION
This is the extensions for labeled KPIs provided by the C-DEngine since changes contained in the [CDE-Repos Pull Reuest 64](https://github.com/TRUMPF-IoT/C-DEngine/pull/64).

It considers the `[LabeledKpis]` sub property and builds and provides the Prometheus metrics, but requires a configuration like;
`[QSenders].[LabeledKpis];cde_qs_count_per_scope` in the `CDMyPrometheusExporter.cdescript` config file to activate the extraction of the KPIs stored in this sub property.

This change requires the C-DEngines pull request mentioned above to be completed.