### PR TITLE
Bump prometheus-net to 8.1.1

### DIFF
--- a/src/188 - PrometheusExporter/CDMyPrometheusExporter/CDMyPrometheusExporter.csproj
+++ b/src/188 - PrometheusExporter/CDMyPrometheusExporter/CDMyPrometheusExporter.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="prometheus-net" Version="8.1.0" />
+    <PackageReference Include="prometheus-net" Version="8.1.1" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
The prometheus-net release solved an issue where exceptions (debug log output errors) occured when requesting metrics:
See https://github.com/prometheus-net/prometheus-net/issues/452 for more information.

This PR just updates this dependency.